### PR TITLE
Optionally handle X-Forwarded-Proto for docker deployment

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,6 +6,7 @@ case "$1" in
         export SYNCSERVER_SQLURI="${SYNCSERVER_SQLURI:-sqlite:///tmp/syncserver.db}"
         exec gunicorn \
             --bind ${HOST-0.0.0.0}:${PORT-5000}\
+            --forwarded-allow-ips="${SYNCSERVER_FORWARDED_ALLOW_IPS:-127.0.0.1}"
             syncserver.wsgi_app
         ;;
 


### PR DESCRIPTION
In the default configuration gunicorn respects the X-Forwarded-Proto HTTP header only if the connection comes from localhost.
This is not the case when e.g. running under docker where gunicorn sees the docker gateway IP causing it to disregard the header and potentially produce an error regarding the mismatch of public_url and application url.
The commandline argument --forwarded-allow-ips tells gunicorn to trust the headers if the connection originates from certain other IP addresses.
To expose this setting for docker setups of syncserver, the docker entrypoint is changed to optionally set this argument based on the environment variable SYNCSERVER_FORWARDED_ALLOW_IPS defaulting to 127.0.0.1 which mirrors the gunicorn default.